### PR TITLE
Question filename fix

### DIFF
--- a/src/quiz-result/quiz-result-helper.ts
+++ b/src/quiz-result/quiz-result-helper.ts
@@ -79,7 +79,7 @@ async function saveAllQuestions() {
 
             // download
 
-            const fileName = `question_${question_slug}_${good ? 'good' : 'bad'}.png`;
+            const fileName = `question_${question_slug.split("_").slice(0, 15).join("_")}_${good ? 'good' : 'bad'}.png`;
 
             const link = document.createElement('a');
             link.download = fileName;


### PR DESCRIPTION
In some cases the file name was too long for Windows to save it. In these cases the _good of _bad suffix was not added.
Eg:
![image](https://github.com/user-attachments/assets/633faa1e-aafc-4180-bf8a-b85f55988783)
Limited the question slug to the first 15 words.